### PR TITLE
Some fixes in VI

### DIFF
--- a/examples/q_learning_viz_example.py
+++ b/examples/q_learning_viz_example.py
@@ -7,23 +7,39 @@ import argparse
 # Other imports.
 import srl_example_setup
 from simple_rl.agents import QLearningAgent, RMaxAgent
-from simple_rl.run_experiments import run_single_agent_on_mdp 
+from simple_rl.run_experiments import run_single_agent_on_mdp
 from simple_rl.tasks import FourRoomMDP, TaxiOOMDP, GridWorldMDP
 from simple_rl.tasks.grid_world.GridWorldMDPClass import make_grid_world_from_file
 from simple_rl.planning import ValueIteration
 
+
 def parse_args():
     # Add all arguments
     parser = argparse.ArgumentParser()
-    parser.add_argument("-v", type=str, default="learning", nargs='?', help="Choose the visualization type (one of {value, policy, agent, learning or interactive}).")
+    parser.add_argument(
+        "-v",
+        type=str,
+        default="learning",
+        nargs='?',
+        help=
+        "Choose the visualization type (one of {value, policy, agent, learning or interactive})."
+    )
     args = parser.parse_args()
     return args.v
 
+
 def main():
-    
+
     # Setup MDP, Agents.
-    mdp = GridWorldMDP(width=7, height=7, init_loc=(1, 1), goal_locs=[(7, 7)], lava_locs=[(4, 2)], gamma=0.95, walls=[(2, 2)], slip_prob=0.1)
-    ql_agent = QLearningAgent(mdp.get_actions(), epsilon=0.95, alpha=0.2) 
+    mdp = GridWorldMDP(width=7,
+                       height=7,
+                       init_loc=(1, 1),
+                       goal_locs=[(7, 7)],
+                       lava_locs=[(4, 2)],
+                       gamma=0.95,
+                       walls=[(2, 2)],
+                       slip_prob=0.1)
+    ql_agent = QLearningAgent(mdp.get_actions(), epsilon=0.95, alpha=0.2)
     viz = parse_args()
 
     # Choose viz type.
@@ -48,10 +64,14 @@ def main():
     elif viz == "learning":
         # --> Press <r> to reset.
         # Show agent's interaction with the environment.
-        mdp.visualize_learning(ql_agent, delay=0.005, num_ep=500, num_steps=200)
+        mdp.visualize_learning(ql_agent,
+                               delay=0.005,
+                               num_ep=500,
+                               num_steps=200)
     elif viz == "interactive":
         # Press <1>, <2>, <3>, and so on to execute action 1, action 2, etc.
-    	mdp.visualize_interaction()
+        mdp.visualize_interaction()
+
 
 if __name__ == "__main__":
     main()

--- a/examples/q_learning_viz_example.py
+++ b/examples/q_learning_viz_example.py
@@ -31,13 +31,13 @@ def parse_args():
 def main():
 
     # Setup MDP, Agents.
-    mdp = GridWorldMDP(width=5,
-                       height=5,
+    mdp = GridWorldMDP(width=3,
+                       height=3,
                        init_loc=(1, 1),
-                       goal_locs=[(5, 5)],
-                       lava_locs=[(4, 2)],
+                       goal_locs=[(3, 3)],
+                       lava_locs=[(2, 2)],
                        gamma=0.95,
-                       walls=[(2, 2)],
+                       walls=[(1, 2)],
                        slip_prob=0.1)
     ql_agent = QLearningAgent(mdp.get_actions(), epsilon=0.95, alpha=0.2)
     viz = parse_args()

--- a/examples/q_learning_viz_example.py
+++ b/examples/q_learning_viz_example.py
@@ -31,10 +31,10 @@ def parse_args():
 def main():
 
     # Setup MDP, Agents.
-    mdp = GridWorldMDP(width=7,
-                       height=7,
+    mdp = GridWorldMDP(width=5,
+                       height=5,
                        init_loc=(1, 1),
-                       goal_locs=[(7, 7)],
+                       goal_locs=[(5, 5)],
                        lava_locs=[(4, 2)],
                        gamma=0.95,
                        walls=[(2, 2)],

--- a/simple_rl/mdp/MDPClass.py
+++ b/simple_rl/mdp/MDPClass.py
@@ -6,9 +6,10 @@ import copy
 class MDP(object):
     ''' Abstract class for a Markov Decision Process. '''
     
-    def __init__(self, actions, transition_func, reward_func, init_state, gamma=0.99, step_cost=0):
+    def __init__(self, actions, transition_func, reward_func, init_state, gamma=0.99, step_cost=0, transition_prob=None):
         self.actions = actions
         self.transition_func = transition_func
+        self.transition_prob = transition_prob
         self.reward_func = reward_func
         self.gamma = gamma
         self.init_state = copy.deepcopy(init_state)
@@ -47,6 +48,9 @@ class MDP(object):
 
     def get_transition_func(self):
         return self.transition_func
+
+    def get_transition_prob(self):
+        return self.transition_prob
 
     def get_num_state_feats(self):
         return self.init_state.get_num_feats()

--- a/simple_rl/planning/PlannerClass.py
+++ b/simple_rl/planning/PlannerClass.py
@@ -12,6 +12,7 @@ class Planner(object):
         self.actions = mdp.get_actions()
         self.reward_func = mdp.get_reward_func()
         self.transition_func = mdp.get_transition_func()
+        self.transition_prob = mdp.get_transition_prob()
         self.gamma = mdp.gamma
         self.has_planned = False
 

--- a/simple_rl/planning/ValueIterationClass.py
+++ b/simple_rl/planning/ValueIterationClass.py
@@ -18,7 +18,7 @@ else:
 class ValueIteration(Planner):
 
     def __init__(self, mdp, name="value_iter", delta=0.0001, max_iterations=500,
-                 sample_rate=3):
+                 sample_rate=1000):
         '''
         Args:
             mdp (MDP)

--- a/simple_rl/planning/ValueIterationClass.py
+++ b/simple_rl/planning/ValueIterationClass.py
@@ -55,9 +55,12 @@ class ValueIteration(Planner):
 
         for s in self.get_states():
             for a in self.actions:
-                for sample in range(self.sample_rate):
-                    s_prime = self.transition_func(s, a)
-                    self.trans_dict[s][a][s_prime] += 1.0 / self.sample_rate
+                stateList = self.transition_prob(s, a)
+                for s_prime in stateList:
+                    self.trans_dict[s][a][s_prime[0]] += s_prime[1]
+#                for sample in range(self.sample_rate):
+#                    s_prime = self.transition_func(s, a)
+#                    self.trans_dict[s][a][s_prime] += 1.0 / self.sample_rate
 
         self.has_computed_matrix = True
 

--- a/simple_rl/tasks/grid_world/GridWorldMDPClass.py
+++ b/simple_rl/tasks/grid_world/GridWorldMDPClass.py
@@ -200,7 +200,7 @@ class GridWorldMDP(MDP):
         if state.is_terminal():
             return state
         
-        if not(self._is_goal_state_action(state, action)) and self.slip_prob > random.random():
+        if self.slip_prob > random.random():
             # Flip dir.
             if action == "up":
                 action = random.choice(["left", "right"])

--- a/simple_rl/tasks/grid_world/grid_visualizer.py
+++ b/simple_rl/tasks/grid_world/grid_visualizer.py
@@ -47,7 +47,7 @@ def _draw_state(screen,
         else:
             if value:
                 vi = ValueIteration(grid_mdp, sample_rate=10)
-                vi.run_vi()
+#                vi.run_vi()
                 for s in vi.get_states():
                     val_text_dict[s.x][s.y] = value(s)
             else:
@@ -62,7 +62,7 @@ def _draw_state(screen,
     if policy:
 #        pass
         vi = ValueIteration(grid_mdp)
-        vi.run_vi()
+#        vi.run_vi()
         for s in vi.get_states():
             policy_dict[s.x][s.y] = policy(s)
 

--- a/simple_rl/tasks/grid_world/grid_visualizer.py
+++ b/simple_rl/tasks/grid_world/grid_visualizer.py
@@ -96,6 +96,10 @@ def _draw_state(screen,
                 if show_value and not grid_mdp.is_wall(i+1, grid_mdp.height - j):
                     # Draw the value.
                     val = val_text_dict[i+1][grid_mdp.height - j]
+                    if (i+1, grid_mdp.height - j) in goal_locs:
+                        val = 1 
+                    if (i+1, grid_mdp.height - j) in lava_locs:
+                        val = -grid_mdp.lava_cost 
                     color = mdpv.val_to_color(val)
                     pygame.draw.rect(screen, color, top_left_point + (cell_width, cell_height), 0)
 

--- a/simple_rl/utils/mdp_visualizer.py
+++ b/simple_rl/utils/mdp_visualizer.py
@@ -354,7 +354,7 @@ def visualize_agent(mdp, agent, draw_state, cur_state=None, scr_width=720, scr_h
                 agent_shape = draw_state(screen, mdp, cur_state, agent_shape=agent_shape)
 
                 # Update state text.
-                _draw_lower_left_text(cur_state, screen)
+                # _draw_lower_left_text(cur_state, screen)
 
         if cur_state.is_terminal():
             # Done! Agent found goal.
@@ -405,7 +405,7 @@ def visualize_interaction(mdp, draw_state, cur_state=None, scr_width=720, scr_he
                 agent_shape = draw_state(screen, mdp, cur_state, agent_shape=agent_shape)
 
                 # Update state text.
-                _draw_lower_left_text(cur_state, screen)
+                # _draw_lower_left_text(cur_state, screen)
 
         if cur_state.is_terminal():
             # Done! Agent found goal. Not if the state is lava!! (Tofix)
@@ -424,8 +424,8 @@ def _vis_init(screen, mdp, draw_state, cur_state, agent=None, value=None, score=
     pygame.display.update()
     done = False
 
-    if score != -1:
-        _draw_lower_left_text("Score: " + str(score), screen)
+    # if score != -1:
+        # _draw_lower_left_text("Score: " + str(score), screen)
     agent_shape = draw_state(screen=screen, grid_mdp=mdp, value=value, state=cur_state, agent=agent, show_value=True, draw_statics=True)
 
     return agent_shape


### PR DESCRIPTION
This fixes several problems in value iteration codes.
1. use slip_prob for transition probability directly, instead of using sampling.
2. show the reward of goal and lava.
3. make is_lava_terminal consistent, default=True
4. remove unnecessary run_vi()
5. remove the rule that slip_prob ignored when the intended direction reaches goal.